### PR TITLE
Update CONTRIBUTING.md go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ TiDB is written in [Go](http://golang.org).
 If you don't have a Go development environment,
 please [set one up](http://golang.org/doc/code.html).
 
-The version of GO should be **1.12** or above.
+The version of GO should be **1.13** or above.
 
 After installation, there are two ways to build TiDB binary.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ export GOPATH=$HOME/go
 export PATH=$PATH:$GOPATH/bin
 ```
 
+Then you can use `make` command to build TiDB.
+
 #### Dependency management
 
 TiDB uses [`Go Modules`](https://github.com/golang/go/wiki/Modules) to manage dependencies.


### PR DESCRIPTION
Seems for me only 1.13 works. 

Using 1.12 give me error:
```
make
CGO_ENABLED=1 GO111MODULE=on go build  -tags codes -trimpath  -ldflags '-X "github.com/pingcap/parser/mysql.TiDBReleaseVersion=v2.1.0-beta-2471-g875873b" -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=2019-10-29 06:41:30" -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=875873b7ca4267c0bbb2e4fe31c1561dea3f495d" -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=master" -X "github.com/pingcap/tidb/util/printer.GoVersion=go version go1.12 darwin/amd64" ' -o bin/tidb-server tidb-server/main.go
flag provided but not defined: -trimpath
usage: go build [-o output] [-i] [build flags] [packages]
Run 'go help build' for details.
make: *** [server] Error 2
```