### PR TITLE
working-groups: add description for `wg-stmt-summary`

### DIFF
--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -17,3 +17,4 @@ policies.
 * [wg-dynamic-configuration-change](./wg-dynamic-configuration-change.md)
 * [wg-tidb-sequence](./wg-tidb-sequence.md)
 * [wg-multi-dc-enhancement (TiKV)](https://github.com/tikv/community/tree/master/wg/multiple-dc-enhancemant)
+* [wg-stmt-summary](./wg-stmt-summary.md)

--- a/working-groups/wg-stmt-summary.md
+++ b/working-groups/wg-stmt-summary.md
@@ -2,7 +2,7 @@
 
 ## Goals
 
-Discussion for the designing of statement summary tables in TiDB.
+Discussion on the design of statement summary tables in TiDB.
 
 Now we have a statement summary table [events\_statements\_summary\_by\_digest](https://pingcap.com/docs/stable/reference/performance/statement-summary/), and more features are being added to it. But we also have some details to be discussed.
 

--- a/working-groups/wg-stmt-summary.md
+++ b/working-groups/wg-stmt-summary.md
@@ -6,9 +6,9 @@ Discussion for the designing of statement summary tables in TiDB.
 
 Now we have a statement summary table [events\_statements\_summary\_by\_digest](https://pingcap.com/docs/stable/reference/performance/statement-summary/), and more features are being added to it. But we also have some details to be discussed.
 
-## Current Issues
+## Meetings
 
-[About table design](https://github.com/pingcap/tidb/issues/13426)
+Currently, we don't have an open meeting because there's only one developer in this working group.
 
 ## Organizer
 

--- a/working-groups/wg-stmt-summary.md
+++ b/working-groups/wg-stmt-summary.md
@@ -1,0 +1,20 @@
+# Statement Summary Working Group
+
+## Goals
+
+Discussion for the designing of statement summary tables in TiDB.
+
+Now we have a statement summary table [events\_statements\_summary\_by\_digest](https://pingcap.com/docs/stable/reference/performance/statement-summary/), and more features are being added to it. But we also have some details to be discussed.
+
+## Current Issues
+
+[About table design](https://github.com/pingcap/tidb/issues/13426)
+
+## Organizer
+
+* [djshow832](https://github.com/djshow832), PingCAP
+
+## Contact
+
+* Slack: channel **#wg-stmt-summary** in the
+  [tidbcommunity](https://pingcap.com/tidbslack) slack workspace.

--- a/working-groups/wg-stmt-summary.md
+++ b/working-groups/wg-stmt-summary.md
@@ -10,6 +10,8 @@ Now we have a statement summary table [events\_statements\_summary\_by\_digest](
 
 Currently, we don't have an open meeting because there's only one developer in this working group.
 
+* Weekly progress summary: [progress summary](https://docs.google.com/document/d/1sUHYrHjsf7fmW23xWlv2FuMysOjm5lbSoK8Iq9ppHOo/edit#)
+
 ## Organizer
 
 * [djshow832](https://github.com/djshow832), PingCAP


### PR DESCRIPTION
Add a new working group `wg-stmt-summary`. This working group is intended to discuss details of statement summary tables in TiDB.