### PR TITLE
proposal: run Discourse on TiDB

### DIFF
--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -13,7 +13,7 @@ The proposal aims at:
 
 ## Background
 
-The TiDB User Group Website: [AskTUG](https://asktug.com) is running on Discourse, and Discourse is running on PostgreSQL, we want to migrate it to TiDB. Then we can frequently test TiDB before each release.
+The TiDB User Group Website: [AskTUG](https://asktug.com) is running on Discourse, and Discourse is running on PostgreSQL. We want to migrate it to TiDB. Then we can frequently test TiDB before each release.
 
 ## Proposal
 

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -21,7 +21,7 @@ We will make these changes:
 
 1. Make most SQL statements of Discourse run on MySQL;
 2. Add new elastic search  componentinstead of PostgreSQL's full-text search;
-3. Migrate from MySQL to TiDB, fix potential compatible problems;
+3. Migrate from MySQL to TiDB, and fix potential compatibility problems;
 
 ## Rationale
 

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -8,7 +8,7 @@
 
 The proposal aims at:
 
-1. **Eat our own dog food**;
+1. **Eating our own dog food**;
 2. Connect TiDB Community with Discourse Community and Ruby On Rails Community;
 
 ## Background

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -20,7 +20,7 @@ The TiDB User Group Website: [AskTUG](https://asktug.com) is running on Discours
 We will make these changes:
 
 1. Make most SQL statements of Discourse run on MySQL;
-2. Add new component elastic search instead of PostgreSQL's fulltext search;
+2. Add new elastic search  componentinstead of PostgreSQL's full-text search;
 3. Migrate from MySQL to TiDB, fix potential compatible problems;
 
 ## Rationale

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -9,7 +9,7 @@
 The proposal aims at:
 
 1. **Eating our own dog food**;
-2. Connect TiDB Community with Discourse Community and Ruby On Rails Community;
+2. Connecting TiDB Community with Discourse Community and Ruby On Rails Community;
 
 ## Background
 

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -25,7 +25,7 @@ We will make these changes:
 
 ## Rationale
 
-Translate sql in PostgreSQL to MySQL within Rails's ORM
+Translate SQL statements from PostgreSQL to MySQL within Rails's ORM
 
 ## Compatibility
 

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -33,8 +33,8 @@ There is no compatibility issues to TiDB.
 
 ## Implementation
 
-1. Migrate Discourse from PostgreSQL to MySQL. @hooopo till Dec 5, 2019
-2. Migrate Discourse from MySQL to TiDB, @wd0517 till Dec 15, 2019
+1. Migrate Discourse from PostgreSQL to MySQL. @[hooopo](https://github.com/hooopo) till Dec 5, 2019
+2. Migrate Discourse from MySQL to TiDB, @[wd0517](https://github.com/wd0517) till Dec 15, 2019
 
 ## Open issues (if applicable)
 

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -1,0 +1,41 @@
+# Proposal: Migrate Discourse's db from PostgreSQL to TiDB
+
+- Author(s): EE-Team
+- Last updated:  Nov 19, 2019
+- Discussion at: https://github.com/pingcap-incubator/discourse/issues/
+
+## Abstract
+
+The proposal aim at:
+
+1. **Eat our own dog food**;
+2. Connect TiDB Community with Discourse Community and Ruby On Rails Community;
+
+## Background
+
+The TiDB User Group Website: [AskTUG](https://asktug.com) is running on Discourse, and Discourse is running on PostgreSQL, we want to migrate it to TiDB. Then we can frequently test TiDB before each release.
+
+## Proposal
+
+We will make these changes:
+
+1. Make Discourse's most sql statemennt run on MySQL;
+2. Add new component elastic search instead of PostgreSQL's fulltext search;
+3. Migrate from MySQL to TiDB, fix potential compatible problems;
+
+## Rationale
+
+Translate sql in PostgreSQL to MySQL within Rails's ORM
+
+## Compatibility
+
+There is no compatibility issues to TiDB.
+
+## Implementation
+
+1. Migrate Discourse from PostgreSQL to MySQL. @hooopo till Dec 5, 2019
+2. Migrate Discourse from MySQL to TiDB, @wd0517 till Dec 15, 2019
+
+## Open issues (if applicable)
+
+No issues.

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -19,7 +19,7 @@ The TiDB User Group Website: [AskTUG](https://asktug.com) is running on Discours
 
 We will make these changes:
 
-1. Make Discourse's most sql statemennt run on MySQL;
+1. Make most SQL statements of Discourse run on MySQL;
 2. Add new component elastic search instead of PostgreSQL's fulltext search;
 3. Migrate from MySQL to TiDB, fix potential compatible problems;
 

--- a/rfc/2019-11-28-discourse-on-tidb.md
+++ b/rfc/2019-11-28-discourse-on-tidb.md
@@ -6,7 +6,7 @@
 
 ## Abstract
 
-The proposal aim at:
+The proposal aims at:
 
 1. **Eat our own dog food**;
 2. Connect TiDB Community with Discourse Community and Ruby On Rails Community;

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -9,3 +9,6 @@ See [TiDB Design Documents](https://github.com/pingcap/tidb/tree/master/docs/des
 See [TiKV RFCs](https://github.com/tikv/rfcs) for details.
 
 ## Other RFCs
+
+- [Run Discourse on TiDB](https://github.com/pingcap/community/rfc/2019-11-28-discourse-on-tidb.md)
+


### PR DESCRIPTION
Signed-off-by: sykp241095@gmail.com

## Summary
This is a proposal about migration of Discourse's database from PostgreSQL to MySQL.

## Motivation
1. Eat our own dog food before release;
2. This migration is a big event in both TiDB community and Discourse(Rails) Community;
