### PR TITLE
Fix: update dead link in contributors document

### DIFF
--- a/contributors/README.md
+++ b/contributors/README.md
@@ -87,7 +87,7 @@ label in the tidb repository. These issues are well suited for new contributors.
 there's always a need for more test coverage. You can also start with an area
 that has [low coverage](https://codecov.io/gh/pingcap/tidb).
 
-You can also join one of the [active working groups](./working-groups) to
+You can also join one of the [active working groups](../working-groups) to
 participate in a community activity. Start with attending working group meetings or
 joining the slack channel.
 


### PR DESCRIPTION
## What dose this PR do

Update the link to the page `active working groups`.