### PR TITLE
SIG: remove co-leads

### DIFF
--- a/special-interest-groups/sig-ddl/member-list.md
+++ b/special-interest-groups/sig-ddl/member-list.md
@@ -17,11 +17,7 @@ Members and their contributions:
 
 ## Tech Leads
 
-Leads:
 * [zimulala](https://github.com/zimulala), [PingCAP](https://pingcap.com/en/)
 * [tangenta](https://github.com/tangenta), [PingCAP](https://pingcap.com/en/)
-
-Co-Leads:
-
 * [kennytm](https://github.com/kennytm), [PingCAP](https://pingcap.com/en/)
 * [tiancaiamao](https://github.com/tiancaiamao), [PingCAP](https://pingcap.com/en/)

--- a/special-interest-groups/sig-exec/member-list.md
+++ b/special-interest-groups/sig-exec/member-list.md
@@ -36,11 +36,6 @@ Members and their contributions:
 
 ## Technical Leads
 
-Lead:
-
 * [qw4990](https://github.com/qw4990), [PingCAP](https://pingcap.com/en/)
-
-Co-Leads:
-
 * [XuHuaiyu](https://github.com/XuHuaiyu), [PingCAP](https://pingcap.com/en/)
 * [SunRunAway](https://github.com/SunRunAway), [PingCAP](https://pingcap.com/en/)

--- a/special-interest-groups/sig-planner/member-list.md
+++ b/special-interest-groups/sig-planner/member-list.md
@@ -17,6 +17,6 @@ Members and their contributions:
 
 None
 
-## Technical Leads
+## Tech Leads
 
-pingcap/co-planner[https://github.com/orgs/pingcap/teams/co-planner]
+* [winoros](https://github.com/winoros), [PingCAP](https://pingcap.com/en/)


### PR DESCRIPTION
Actually we don't have co-leads, this PR removes the description for co-leads