### PR TITLE
sig: update #sig-docs slack link

### DIFF
--- a/special-interest-groups/sig-docs/README.md
+++ b/special-interest-groups/sig-docs/README.md
@@ -36,7 +36,7 @@ There is no regular meeting currently.
 
 ## Contact
 
-* Slack: [#sig-docs](http://suo.im/6lRF17)
+* Slack: [#sig-docs](https://slack.tidb.io/invite?team=tidb-community&channel=sig-docs&ref=pingcap-community)
 
 ## Code Locations
 


### PR DESCRIPTION
Update the normal link of joining #sig-docs Slack channel.