### PR TITLE
sepical_interest_group/readme: update active sigs and add more information for sigs and how to contribute

### DIFF
--- a/special-interest-groups/README.md
+++ b/special-interest-groups/README.md
@@ -23,6 +23,8 @@ SIG.
 * [K8S](./sig-k8s)
 * [Tools](./sig-tools)
 * [TiDB Dashboard](./sig-dashboard)
+* [TiUP](./sig-tiup)
+* [web](./sig-web)
 
 ### TiKV
 
@@ -31,7 +33,6 @@ SIG.
 * [Raft](https://github.com/tikv/community/tree/master/sig/raft)
 * [Performance](https://github.com/tikv/community/tree/master/sig/performance)
 * [Transaction](https://github.com/tikv/community/tree/master/sig/transaction)
-* [Ecosystem](https://github.com/tikv/community/tree/master/sig/ecosystem)
 * [Scheduling](./sig-scheduling)
 
 ### Documentation

--- a/special-interest-groups/README.md
+++ b/special-interest-groups/README.md
@@ -7,8 +7,9 @@ specific topic, such as Parser/Expression/Planner. Our goal is to enable a
 distributed decision structure and code ownership, as well as providing focused
 forums for getting work done, making decisions, and onboarding new
 contributors. Every identifiable subpart of the project (e.g., github org,
-repository, subdirectory, API, test, issue, PR) is intended to be owned by some
-SIG.
+repository, subdirectory, API, test, issue, PR) is intended to be owned by some SIG. For more details about sig governance, you can read this doc [sig governance](./governance/sig-governance.md). 
+And if you are new to tidb, and want to find a sig to start, this [contribution map for sig](https://github.com/pingcap/tidb-map/blob/master/maps/contribution-map.md#sig---special-interest-group) may be helpful.
+
 
 ## Active Special Interest Groups
 


### PR DESCRIPTION
Signed-off-by: wuxuelian <AndreMouche@126.com>		

Hi, This PR  update the README docs with the following items:
- active sigs
- information about sig governance
- information about how to contribute in sig