### PR TITLE
sig: update the sig-exec member list

### DIFF
--- a/special-interest-groups/sig-exec/member-list.md
+++ b/special-interest-groups/sig-exec/member-list.md
@@ -16,6 +16,12 @@
 - [Reminiscent](https://github.com/Reminiscent)
 - [wshwsh12](https://github.com/wshwsh12)
 - [qw4990](https://github.com/qw4990)
+- [crazycs520](https://github.com/crazycs520)
+- [jackysp](https://github.com/jackysp)
+- [tiancaiamao](https://github.com/tiancaiamao)
+- [coocood](https://github.com/coocood)
+- [lysu](https://github.com/lysu)
+
 
 ## Reviewers
 


### PR DESCRIPTION
Add these committers:
1. crazycs520: contribute 98 PRs about exec and add the memory table `slow-query` for TiDB;
2. tiancaiamao: contribute 82 PRs about exec and implement partition tables for TiDB;
3. jackysp: contribute 62 PRs about exec;
4. lysu: contribute 59 PRs about exec and implement the `prepare-stmt` for TiDB;
5. coocood: design and implement clustered index for TiDB;