### PR TITLE
Add wg-tracing working group

### DIFF
--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -37,3 +37,4 @@ See [Working Group Template](./wg-template.md) for details.
 * [wg-dumpling](./wg-dumpling.md)
 * [wg-online-restore](./wg-online-restore.md)
 * [wg-talent-plan-courses](./wg-talent-plan-courses.md)
+* [wg-tracing](./wg-tracing.md)

--- a/working-groups/wg-tracing.md
+++ b/working-groups/wg-tracing.md
@@ -14,9 +14,9 @@ You can track work items and see more details in the [Timeline Tracing project](
 
 ## Organizers
 
-- [breeswish](https://github.com/breeswish), [PingCAP](https://github.com/pingcap)
 - [zhongzc](https://github.com/zhongzc), [PingCAP](https://github.com/pingcap)
 - [qw4990](https://github.com/qw4990), [PingCAP](https://github.com/pingcap)
+- [breeswish](https://github.com/breeswish), [PingCAP](https://github.com/pingcap)
 
 ## Members
 

--- a/working-groups/wg-tracing.md
+++ b/working-groups/wg-tracing.md
@@ -1,0 +1,27 @@
+# Timeline Tracing Working Group
+
+## Goals
+
+This working group aims to implement the Timeline Tracing feature in TiDB, TiKV, TiDB Dashboard and other related components.
+
+Timeline Tracing adds a new tracing layer to both TiDB and TiKV. The existing low-performance tracing facility in TiDB will be dropped. TiKV traces the time of each specific event in the request and packs them along with the response. Timeline Tracing should be enabled by default and has <1% performance impact.
+
+Although the implementation involves with multiple components, end-users will mostly interact with TiDB Dashboard to utilize this feature. A sample UI looks like the tracing UI provided by DataDog:
+
+![DataDog Tracing UI](https://user-images.githubusercontent.com/1916485/83112013-17367580-a0f8-11ea-8875-27ee90a68ad0.png)
+
+You can track work items and see more details in the [Timeline Tracing project](https://github.com/pingcap-incubator/tidb-dashboard/projects/23).
+
+## Organizers
+
+- [breeswish](https://github.com/breeswish), [PingCAP](https://github.com/pingcap)
+- [zhongzc](https://github.com/zhongzc), [PingCAP](https://github.com/pingcap)
+- [qw4990](https://github.com/qw4990), [PingCAP](https://github.com/pingcap)
+
+## Members
+
+You can join the Slack channel to see all members. See [Contact](#contact) section.
+
+## Contact
+
+- Slack: [#wg-tracing](https://slack.tidb.io/invite?team=tidb-community&channel=wg-tracing&ref=github_wg)


### PR DESCRIPTION
This PR creates a new working group: Timeline Tracing Working Group (wg-tracing).

Signed-off-by: Breezewish <me@breeswish.org>