### PR TITLE
Update member list of sig-dashboard

### DIFF
--- a/special-interest-groups/sig-dashboard/README.md
+++ b/special-interest-groups/sig-dashboard/README.md
@@ -1,4 +1,4 @@
-# Dashboard Special Interest Group (Dashboard SIG)
+# TiDB Dashboard Special Interest Group (sig-dashboard)
 
 We focus on the **development** of the [TiDB Dashboard](https://github.com/pingcap-incubator/tidb-dashboard).
 

--- a/special-interest-groups/sig-dashboard/member-list.md
+++ b/special-interest-groups/sig-dashboard/member-list.md
@@ -1,20 +1,17 @@
-# Dashboard SIG Member List
+# TiDB Dashboard SIG Member List
 
 Note: This file only lists members of **Active Contributor** role or above. See [TiDB Community Architecture](https://github.com/pingcap/community/blob/master/architecture/README.md) and [Dashboard SIG Roles and Organization Management](./roles-and-organization-management.md) for details about roles.
 
 ## Tech Leaders
 
-- [@breeswish](https://github.com/breeswish)
-- [@HunDunDM](https://github.com/HunDunDM)
-- [@baurine](https://github.com/baurine)
+- [@breeswish](https://github.com/breeswish) (PingCAP)
+- [@HunDunDM](https://github.com/HunDunDM) (PingCAP)
+- [@baurine](https://github.com/baurine) (PingCAP)
 
 ## Committers
 
 - [@crazycs520](https://github.com/crazycs520) (PingCAP)
-- [@Deardrops](https://github.com/Deardrops) (PingCAP)
-- [@rleungx](https://github.com/rleungx) (PingCAP)
-- [@mapleFU](https://github.com/mapleFU) (PingCAP)
-- [@reafans](https://github.com/reafans) (PingCAP)
+- [@Deardrops](https://github.com/Deardrops)
 
 ## Reviewers
 
@@ -22,7 +19,9 @@ None
 
 ## Active Contributors
 
-None
+- [@rleungx](https://github.com/rleungx) (PingCAP)
+- [@mapleFU](https://github.com/mapleFU)
+- [@reafans](https://github.com/reafans)
 
 ## Inactive Contributors
 

--- a/special-interest-groups/sig-dashboard/roles-and-organization-management.md
+++ b/special-interest-groups/sig-dashboard/roles-and-organization-management.md
@@ -1,4 +1,4 @@
-# Dashboard SIG Roles and Organization Management
+# TiDB Dashboard SIG Roles and Organization Management
 
 ## Join and Promotion
 


### PR DESCRIPTION
Previously there are some misunderstandings when adding PingCAP members to the member list. Now I refined the member list and their roles according to the charter.

Signed-off-by: Breezewish <me@breeswish.org>