### PR TITLE
sig-scheduling: promote JmPotato to the active contributor

### DIFF
--- a/special-interest-groups/sig-scheduling/member-list.md
+++ b/special-interest-groups/sig-scheduling/member-list.md
@@ -36,3 +36,4 @@ None
 ## Active Contributors
 
 * [mantuliu](https://github.com/mantuliu), [Hive Box](https://www.fcbox.com/en)
+* [JmPotato](https://github.com/JmPotato), [PingCAP](https://pingcap.com/en/)


### PR DESCRIPTION
[JmPotato](https://github.com/JmPotato) has contributed [10](https://github.com/pingcap/pd/pulls?q=is%3Apr+is%3Aclosed+author%3AJmPotato) PRs. This PR is going to promote him to be an active contributor.