### PR TITLE
sig-k8s: Promote Mike to reviewer

### DIFF
--- a/special-interest-groups/sig-k8s/member-list.md
+++ b/special-interest-groups/sig-k8s/member-list.md
@@ -32,6 +32,7 @@
 ## Reviewers
 
 * [lichunzhu](https://github.com/lichunzhu)
+* [mikechengwei](https://github.com/mikechengwei)
 
 ## Active Contributors
 


### PR DESCRIPTION
@mikechengwei has done great work in tidb-operator development. List of contributions: https://github.com/pingcap/tidb-operator/pulls/mikechengwei 

We've decided to promote him to the reviewer of sig-k8s!