### PR TITLE
sig-planner: promote SunRunAway to committer

### DIFF
--- a/special-interest-groups/sig-planner/member-list.md
+++ b/special-interest-groups/sig-planner/member-list.md
@@ -19,7 +19,6 @@
 - [imtbkcat](https://github.com/imtbkcat)
 - [wjhuang2016](https://github.com/wjhuang2016)
 - [zz-jason](https://github.com/zz-jason)
-- [SunRunAway](https://github.com/SunRunAway)
 - [lamxTyler](https://github.com/lamxTyler)
 
 ## Committers
@@ -28,6 +27,7 @@
 - [francis0407](https://github.com/francis0407)
 - [eurekaka](https://github.com/eurekaka)
 - [qw4990](https://github.com/qw4990)
+- [SunRunAway](https://github.com/SunRunAway)
 - [XuHuaiyu](https://github.com/XuHuaiyu)
 
 ## Tech Leads


### PR DESCRIPTION
SunRunAway: Fix more than 30 bugs and support distinct aggregation push down in planner, so I promote him to committer formally.