### PR TITLE
*: update SIG-DDL member-list

### DIFF
--- a/special-interest-groups/sig-ddl/member-list.md
+++ b/special-interest-groups/sig-ddl/member-list.md
@@ -23,10 +23,12 @@
 - [XuHuaiyu](https://github.com/XuHuaiyu)
 - [spongedu](https://github.com/spongedu)
 - [Deardrops](https://github.com/Deardrops)
+- [xhebox](https://github.com/xhebox)
 
 ## Active Contributors
 
 - [reafans](https://github.com/reafans)
 - [Rustin-Liu](https://github.com/Rustin-Liu)
+- [xiongjiwei](https://github.com/xiongjiwei)
+- [wangggong](https://github.com/wangggong)
 - [zhaox1n](https://github.com/zhaox1n)
-- [xhebox](https://github.com/xhebox)


### PR DESCRIPTION
The following is the number of PR that contributors have been merged:
xhebox merged 21 PRs
xiongjiwei merged 11 PRs
wangggong merged 10 PRs