### PR TITLE
Promote 9547 as active contributor of TiUP

### DIFF
--- a/special-interest-groups/sig-tiup/member-list.md
+++ b/special-interest-groups/sig-tiup/member-list.md
@@ -3,7 +3,7 @@
 **NOTE**:
 
 * This member list is updated on a bi-weekly basis.
-* Last update time: 2020-03-13
+* Last update time: 2020-09-22
 
 ## Tech Leads
 

--- a/special-interest-groups/sig-tiup/member-list.md
+++ b/special-interest-groups/sig-tiup/member-list.md
@@ -26,3 +26,4 @@
 * [c4pt0r](https://github.com/c4pt0r), [PingCAP](https://pingcap.com/en/)
 * [qinzuoyan](https://github.com/qinzuoyan), [XiaoMi](https://github.com/XiaoMi)
 * [YangKeao](https://github.com/YangKeao), [PingCAP](https://pingcap.com/en/)
+* [9547](https://github.com/9547)


### PR DESCRIPTION
This contributor has contribute [13 PRs](https://github.com/pingcap/tiup/pulls?q=is%3Apr+author%3A9547) (11 merged) for [TiUP repo](https://github.com/pingcap/tiup). It's time to promote him as an active contributor.