### PR TITLE
sig-k8s: Promote shonge as reviewer

### DIFF
--- a/special-interest-groups/sig-k8s/member-list.md
+++ b/special-interest-groups/sig-k8s/member-list.md
@@ -34,11 +34,11 @@
 * [lichunzhu](https://github.com/lichunzhu)
 * [mikechengwei](https://github.com/mikechengwei)
 * [july2993](https://github.com/july2993)
+* [shonge](https://github.com/shonge)
 
 ## Active Contributors
 
 * [xiaojingchen](https://github.com/xiaojingchen)
-* [shonge](https://github.com/shonge)
 * [cwen0](https://github.com/cwen0)
 * [kolbe](https://github.com/kolbe)
 * [sokada1221](https://github.com/sokada1221)


### PR DESCRIPTION
@shonge is an active contributor of sig-k8s and contributed almost 30 PRs (25 merged). I promote him as our reviwer and participart code-review. see contributions: https://github.com/pingcap/tidb-operator/commits?author=shonge