### PR TITLE
update member list for sig/ddl, promote xiongjiwei to reviewer

### DIFF
--- a/special-interest-groups/sig-ddl/member-list.md
+++ b/special-interest-groups/sig-ddl/member-list.md
@@ -24,11 +24,11 @@
 - [spongedu](https://github.com/spongedu)
 - [Deardrops](https://github.com/Deardrops)
 - [xhebox](https://github.com/xhebox)
+- [xiongjiwei](https://github.com/xiongjiwei)
 
 ## Active Contributors
 
 - [reafans](https://github.com/reafans)
 - [Rustin-Liu](https://github.com/Rustin-Liu)
-- [xiongjiwei](https://github.com/xiongjiwei)
 - [wangggong](https://github.com/wangggong)
 - [zhaox1n](https://github.com/zhaox1n)


### PR DESCRIPTION
As stated:

@xiongjiwei has [20+ PRs](https://github.com/pingcap/tidb/pulls?q=is%3Apr+author%3Axiongjiwei+is%3Aclosed) merged in TiDB repo related to DDL and charset, in which:

- Finished the development of https://github.com/pingcap/tidb/issues/17596 (a valuable and difficult work)
- Fixed some major bugs of TiDB, such as: #18665, #19189 #19166