### PR TITLE
update memberlist for sig-DDL, promote xhebox as the commiter.

### DIFF
--- a/special-interest-groups/sig-ddl/member-list.md
+++ b/special-interest-groups/sig-ddl/member-list.md
@@ -16,6 +16,7 @@
 - [AilinKid](https://github.com/AilinKid)
 - [wjhuang2016](https://github.com/wjhuang2016)
 - [djshow832](https://github.com/djshow832)
+- [xhebox](https://github.com/xhebox)
 
 ## Reviewers
 
@@ -23,7 +24,6 @@
 - [XuHuaiyu](https://github.com/XuHuaiyu)
 - [spongedu](https://github.com/spongedu)
 - [Deardrops](https://github.com/Deardrops)
-- [xhebox](https://github.com/xhebox)
 - [xiongjiwei](https://github.com/xiongjiwei)
 
 ## Active Contributors


### PR DESCRIPTION
For the past months, @xhebox is very active in contributing to the TiDB project, his jobs included:

- [20+ merged PRs](https://github.com/pingcap/tidb/pulls?q=is%3Apr+author%3Axhebox+is%3Aclosed) in TiDB repo and [11 merged PRs](https://github.com/pingcap/parser/pulls?q=is%3Apr+author%3Axhebox+is%3Aclosed) in parser repo.
- Closed https://github.com/pingcap/tidb/issues/18756 and https://github.com/pingcap/tidb/issues/19122 that are medium-difficulty issue.
- Finished the development of https://github.com/pingcap/tidb/issues/18030 (AKA the 'geo partition'), which is an important feature of the next version of TiDB.
- Reviewd [10+ PRs](https://github.com/search?q=is%3Apr+reviewed-by%3Axhebox+updated%3A%3E%3D2020-01-01+-author%3Axhebox) since he've been promoted as the reviewer of TiDB community.

So we decided to nominate him as the committer of [SIG DDL](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-ddl/roles-and-organization-management.md) of TiDB community.