### PR TITLE
Promote 9547 as a reviewer of TiUP

### DIFF
--- a/special-interest-groups/sig-tiup/membership.json
+++ b/special-interest-groups/sig-tiup/membership.json
@@ -22,6 +22,9 @@
   ],
   "reviewers": [
     {
+      "githubName": "9547"
+    },
+    {
       "githubName": "breeswish"
     },
     {
@@ -37,9 +40,6 @@
     },
     {
       "githubName": "qinzuoyan"
-    },
-    {
-      "githubName": "9547"
     }
   ]
 }


### PR DESCRIPTION
This active contributor has contributed [28 PRs](https://github.com/pingcap/tiup/pulls?q=is%3Apr+author%3A9547) (25 merged) for [TiUP repo](https://github.com/pingcap/tiup). It's time to promote him as a reviewer.