### PR TITLE
sig-docs: promote Charlotteiu to reviewer

### DIFF
--- a/special-interest-groups/sig-docs/membership.json
+++ b/special-interest-groups/sig-docs/membership.json
@@ -123,6 +123,9 @@
     },
     {
       "githubName": "glkappe"
+    },
+    {
+        "githubName": "CharLotteiu"
     }
   ],
   "activeContributors": [
@@ -223,9 +226,6 @@
       "githubName": "SE-Bin"
     },
     {
-      "githubName": "CharLotteiu"
-    },
-    {
       "githubName": "ireneontheway"
     },
     {
@@ -233,6 +233,12 @@
     },
     {
       "githubName": "xxj123go"
+    },
+    {
+      "githubName": "dragonly"
+    },
+    {
+      "githubName": "leiysky"
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

According to [Be promoted to Reviewer](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-docs/roles-and-organization-management.md#be-promoted-to-reviewer), we would like to promote @CharLotteiu to a new reviewer of Docs SIG. Her detailed contribution is shown below:

- Have 37 PRs merged in documentation repositories within one year
- Improve docs maintenance efficiency:
    - Add conflict mark check in 4 docs repos (https://github.com/pingcap/docs/pull/4026, https://github.com/pingcap/docs-cn/pull/4696, https://github.com/pingcap/docs-dm/pull/438, https://github.com/pingcap/docs-tidb-operator/pull/786)
    - Create [a Chrome extension](https://chrome.google.com/webstore/detail/quickswitch/knjplddkmcgipbanhljlbkphpmkhgkfd?hl=zh-CN&authuser=0) to enable quick switch between Chinese and English documentation