### PR TITLE
Propose @Yisaer as committer of sig-exec

### DIFF
--- a/special-interest-groups/sig-exec/membership.json
+++ b/special-interest-groups/sig-exec/membership.json
@@ -60,6 +60,9 @@
     },
     {
       "githubName": "b41sh"
+    },
+    {
+      "githubName": "Yisaer"
     }
   ],
   "reviewers": [
@@ -77,9 +80,6 @@
     },
     {
       "githubName": "AilinKid"
-    },
-    {
-      "githubName": "Yisaer"
     },
     {
       "githubName": "ichn-hu"


### PR DESCRIPTION
Since @Yisaer has contributed a lot to sig-exec, according to sig-exec [roles-and-organization-management.md#promotion](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-exec/roles-and-organization-management.md#from-reviewer-to-committer), we would like to promote him to our new committer, and his detailed contribution is shown below:

1. contribute [20+](https://github.com/pingcap/tidb/pulls?q=is%3Apr+author%3Ayisaer+label%3Astatus%2Fcan-merge+label%3Asig%2Fexecution) PRs to the executor,
2. support the [global memory tracker](https://github.com/pingcap/tidb/pull/16777) (a medium task)
4. support the ratelimit action to solve the [table reader oom problem](https://github.com/pingcap/tidb/issues/16104) (a hard task)
5. help other contributors and review [25+](https://github.com/pingcap/tidb/pulls?q=is%3Apr+reviewed-by%3Ayisaer+-author%3Ayisaer) PRs.

Thanks for his contribution!!