### PR TITLE
promote mikechengwei as committer of tidb-operator

### DIFF
--- a/special-interest-groups/sig-k8s/membership.json
+++ b/special-interest-groups/sig-k8s/membership.json
@@ -12,6 +12,9 @@
   ],
   "committers": [
     {
+      "githubName": "mikechengwei"
+    },
+    {
       "githubName": "AstroProfundis"
     },
     {
@@ -60,9 +63,6 @@
     },
     {
       "githubName": "shonge"
-    },
-    {
-      "githubName": "mikechengwei"
     },
     {
       "githubName": "howardlau1999"


### PR DESCRIPTION
@mikechengwei has almost 30 [PRs](https://github.com/pingcap/tidb-operator/pulls?q=is%3Apr+author%3Amikechengwei+is%3Aclosed) merged in the tidb-operator repo, 3 [PRs](https://github.com/pingcap/docs-tidb-operator/pulls?q=is%3Apr+author%3Amikechengwei+is%3Aclosed) merged in the docs-tidb-operator repo, and finishes the below big features by himself:

- Heterogeneous cluster deployment https://github.com/pingcap/tidb-operator/issues/2240
- Migrate the deployment of TidbMonitor from deployment to statefulset https://github.com/pingcap/tidb-operator/pull/3440