### PR TITLE
sig-ddl: promote 'blacktear23' to active contributor

### DIFF
--- a/special-interest-groups/sig-ddl/membership.json
+++ b/special-interest-groups/sig-ddl/membership.json
@@ -71,6 +71,9 @@
     },
     {
       "githubName": "zhaox1n"
+    },
+    {
+      "githubName": "blacktear23"
     }
   ]
 }


### PR DESCRIPTION
@blacktear23 is very active in the past few months, his contributions
includes:

- [14 merged
PRs](https://github.com/pingcap/parser/pulls?q=is%3Apr+author%3Ablacktear23+is%3Aclosed) in TiDB repo and 10 of them are
DDL-related
- [2 merged PRs](https://github.com/pingcap/parser/pulls?q=is%3Apr+author%3Ablacktear23+is%3Aclosed) in parser
repo