### PR TITLE
Promote xiongjiwei as the committer for DDL sig

### DIFF
--- a/special-interest-groups/sig-ddl/membership.json
+++ b/special-interest-groups/sig-ddl/membership.json
@@ -41,6 +41,9 @@
     {
       "githubName": "xhebox"
     }
+    {
+      "githubName": "xiongjiwei"
+    }
   ],
   "reviewers": [
     {
@@ -55,9 +58,6 @@
     {
       "githubName": "Deardrops"
     },
-    {
-      "githubName": "xiongjiwei"
-    }
   ],
   "activeContributors": [
     {

--- a/special-interest-groups/sig-ddl/membership.json
+++ b/special-interest-groups/sig-ddl/membership.json
@@ -40,7 +40,7 @@
     },
     {
       "githubName": "xhebox"
-    }
+    },
     {
       "githubName": "xiongjiwei"
     }
@@ -57,7 +57,7 @@
     },
     {
       "githubName": "Deardrops"
-    },
+    }
   ],
   "activeContributors": [
     {


### PR DESCRIPTION
Since @xiongjiwei  has contributed a lot to sig-ddl, according to sig-ddl [roles-and-organization-management.md](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-ddl/roles-and-organization-management.md#promotion), we would like to promote him to our new committer, and his detailed contribution is shown below:

1.  Contribute [20+](https://github.com/pingcap/tidb/pulls?q=is%3Apr+label%3Asig%2FDDL+author%3Axiongjiwei+is%3Aclosed) PRs to the DDL sig.
2. Review [10+](https://github.com/pingcap/tidb/pulls?q=is%3Apr+reviewed-by%3Axiongjiwei+-author%3Axiongjiwei) PRs.
3. Implement unicode-ci in both TiDB and TiKV.
