### PR TITLE
Propose @wjhuang2016 as committer of sig-exec

### DIFF
--- a/special-interest-groups/sig-exec/membership.json
+++ b/special-interest-groups/sig-exec/membership.json
@@ -63,6 +63,9 @@
     },
     {
       "githubName": "Yisaer"
+    },
+    {
+      "githubName": "wjhuang2016"
     }
   ],
   "reviewers": [
@@ -74,9 +77,6 @@
     },
     {
       "githubName": "tangenta"
-    },
-    {
-      "githubName": "wjhuang2016"
     },
     {
       "githubName": "AilinKid"


### PR DESCRIPTION
Since @wjhuang2016 has contributed a lot to sig-exec, according to sig-exec [roles-and-organization-management.md#promotion](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-exec/roles-and-organization-management.md#from-reviewer-to-committer), we would like to promote him to our new committer, and his detailed contribution is shown below:

contribute [30 PRs](https://github.com/pingcap/tidb/pulls?q=is%3Apr+author%3Awjhuang2016+label%3Asig%2Fexecution) to the executor,
support the [expression index](https://github.com/pingcap/tidb/issues/18008) (a medium task)
support the [new collation](https://github.com/pingcap/tidb/issues/14573) (a hard task)
help other contributors and review [150+](https://github.com/pingcap/tidb/pulls?q=is%3Apr+reviewed-by%3Awjhuang2016+-author%3Awjhuang2016+label%3Asig%2Fexecution) PRs.
Thanks for his contribution!!