### PR TITLE
Promote liuzix to committer

### DIFF
--- a/special-interest-groups/sig-migrate/membership.json
+++ b/special-interest-groups/sig-migrate/membership.json
@@ -58,6 +58,9 @@
     },
     {
       "githubName": "holys"
+    },
+    {
+      "githubName": "liuzix"
     }
   ],
   "reviewers": [
@@ -66,9 +69,6 @@
     },
     {
       "githubName": "tiancaiamao"
-    },
-    {
-      "githubName": "liuzix"
     }
   ],
   "activeContributors": [


### PR DESCRIPTION
I (@liuzix) now satisfy the requirements for being promoted to a commiter.

Requirements
- Have at least 30 PRs merged within one year (Yes, 34 PRs in TiCDC)
- Have reviewed at least 20 PRs within one year. (Yes, at least 25 in TiCDC)
- Nominated by at least 2 Committers or Maintainers. (@leoppro @amyangfei PTAL)