### PR TITLE
sig-planner: add reviewers

### DIFF
--- a/special-interest-groups/sig-planner/membership.json
+++ b/special-interest-groups/sig-planner/membership.json
@@ -44,6 +44,15 @@
     },
     {
       "githubName": "lamxTyler"
+    },
+    {
+      "githubName": "time-and-fate"
+    },
+    {
+      "githubName": "Reminiscent"
+    },
+    {
+      "githubName": "rebelice"
     }
   ],
   "activeContributors": [


### PR DESCRIPTION
Promote three reviewer
Both of them contributes many codes for planner-sig.
And designed thing such as new statistics for sampling based data, and the index usage table.