### PR TITLE
sig: Add community-infra sig and submit relevant information

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,3 +24,6 @@ sig/tiup:
 
 sig/web:
   - "special-interest-groups/sig-web/*"
+
+sig/community-infra:
+  - "special-interest-groups/sig-community-infra/*"

--- a/special-interest-groups/README.md
+++ b/special-interest-groups/README.md
@@ -25,6 +25,7 @@ And if you are new to tidb, and want to find a sig to start, this [contribution 
 - [Diagnosis](./sig-diagnosis)
 - [TiUP](./sig-tiup)
 - [web](./sig-web)
+- [Community-Infra](./sig-community-infra)
 
 ### TiKV
 

--- a/special-interest-groups/sig-community-infra/README.md
+++ b/special-interest-groups/sig-community-infra/README.md
@@ -19,7 +19,7 @@ TBD
 
 ## Contact
 
-* Slack: channel #sig-community-infra in the [tidbcommunity](https://pingcap.com/tidbslack) slack workspace.
+* Slack: channel #sig-community-infra in the [tidbcommunity](https://slack.tidb.io/invite?team=tidb-community&channel=sig-community-infra) slack workspace.
 
 ## Code Locations
 

--- a/special-interest-groups/sig-community-infra/README.md
+++ b/special-interest-groups/sig-community-infra/README.md
@@ -1,0 +1,26 @@
+# Community-Infra Special Interest Group(Community-Infra SIG)
+
+Community-Infra SIG covers the development of [tidb-community-bots](https://github.com/tidb-community-bots). Our work includes
+* Support new features or improve community collaboration tools.
+* Fixing all kinds of bugs of community collaboration tools.
+* Improve the usability of community collaboration tools.
+
+## Roles and Organization Management
+
+See [SIG Community-Infra Roles and Organization Management](./roles-and-organization-management.md)
+
+## Members
+
+See [SIG Community-Infra Member List](https://pingcap.com/developer/sig/community-infra)
+
+## Meetings
+
+TBD
+
+## Contact
+
+* Slack: channel #sig-community-infra in the [tidbcommunity](https://pingcap.com/tidbslack) slack workspace.
+
+## Code Locations
+
+* The [tidb-community-bots](https://github.com/tidb-community-bots).

--- a/special-interest-groups/sig-community-infra/membership.json
+++ b/special-interest-groups/sig-community-infra/membership.json
@@ -6,11 +6,11 @@
     }
   ],
   "coLeaders": [],
-  "committers": [],
-  "reviewers": [
+  "committers": [
     {
       "githubName": "Mini256"
     }
   ],
+  "reviewers": [],
   "activeContributors": []
 }

--- a/special-interest-groups/sig-community-infra/membership.json
+++ b/special-interest-groups/sig-community-infra/membership.json
@@ -1,0 +1,16 @@
+{
+  "name": "community-infra",
+  "techLeaders": [
+    {
+      "githubName": "hi-rustin"
+    }
+  ],
+  "coLeaders": [],
+  "committers": [],
+  "reviewers": [
+    {
+      "githubName": "Mini256"
+    }
+  ],
+  "activeContributors": []
+}

--- a/special-interest-groups/sig-community-infra/roles-and-organization-management.md
+++ b/special-interest-groups/sig-community-infra/roles-and-organization-management.md
@@ -1,0 +1,78 @@
+# SIG Community-Infra Roles and Organization Management
+
+## Join and Promotion
+
+We mainly follow the instructions in [TiDB Developer Group](../../architecture/README.md#tidb-developer-group).
+It lists common requirements, responsibilities and privileges of each role in developer group.
+
+### Join
+
+There are no restrictions to join the discussion of Community-Infra SIG. See [README](./README.md) for where we discuss.
+
+However, you will be only listed in our [member list] if you have **Active Contributor** role or above.
+
+### Promotion
+
+#### From `Contributor` to `Active Contributor`
+
+Requirements:
+
+* Have at least 8 PRs merged within one year.
+* Nominated by at least 1 Community-Infra SIG Reviewers or roles above.
+
+#### From `Active Contributor` to `Reviewer`
+
+Requirements:
+
+* Have at least 20 PRs merged within one year.
+* Have fixed at least 2 issues whose difficulty is medium or above within one year.
+* Nominated by at least 2 Committers or 2 Maintainers.
+
+#### From `Reviewer` to `Committer`
+
+Requirements:
+
+* Have at least 30 PRs merged within one year.
+* Have fixed at least 5 issues whose difficulty is medium or above within one year.
+* Have fixed at least 1 issues whose difficulty is hard within one year.
+* Have reviewed at least 20 PRs within one year.
+* Nominated by at least 2 Committers or Maintainers.
+
+## Quit and Demotion
+
+### Active Contributor
+
+**Automatically retired**:
+
+* No contribution to the parser repository within one year.
+
+**How to rejoin**:
+
+* Should meet the requirements for Active Contributor again.
+
+### Reviewer
+
+**Automatically demoted**:
+
+For a Reviewer to be demoted to an Active Contributor,  he/she must satisfy at
+least 1 of the following conditions:
+
+* Haven't reviewed or merged any PR in the parser repository within 3 months.
+* Haven't appeared in the SIG meeting without any reason for 3 times continuously.
+* At least 2 Committers or Maintainers agree that the Reviewer is not qualified.
+
+**How to retain**:
+
+* Have reviewed or merged 5 PRs within 1 month.
+
+### Voluntarily Quit or Demote
+
+You can quit the Community-Infra SIG voluntarily by simply leaving our discussion channel.
+
+- For Reviewers and above: Your name will remain in the [member list] to acknowledge your contribution.
+
+- For Active Contributor: Your name will be moved to Inactive Contributors.
+
+Please open a Pull Request to update the [member list] if you want to completely remove your name from it.
+
+[member list]: membership.json


### PR DESCRIPTION
The community needs some infrastructure tools to enhance the community experience, and we have been working on this part of the infrastructure tools for some time, so we hope to set up a sig to work with the community to maintain and update these infrastructure tools.

