### PR TITLE
sig-docs: promote 3 active contributors

### DIFF
--- a/special-interest-groups/sig-docs/membership.json
+++ b/special-interest-groups/sig-docs/membership.json
@@ -133,13 +133,13 @@
   ],
   "activeContributors": [
     {
-        "githubName": "qw4990"
+      "githubName": "qw4990"
     },
     {
-        "githubName": "scsldb"
+      "githubName": "scsldb"
     },
     {
-        "githubName": "sticnarf"
+      "githubName": "sticnarf"
     },
     {
       "githubName": "zhouqiang-cl"
@@ -236,6 +236,15 @@
     },
     {
       "githubName": "kennytm"
+    },
+    {
+      "githubName": "LittleFall"
+    },
+    {
+      "githubName": "JaySon-Huang"
+    },
+    {
+      "githubName": "yiwu-arbug"
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

Promote 3 contributors to active contributors.