### PR TITLE
Promote 9547 as a committer of TiUP

### DIFF
--- a/special-interest-groups/sig-tiup/membership.json
+++ b/special-interest-groups/sig-tiup/membership.json
@@ -14,16 +14,16 @@
       "githubName": "AstroProfundis"
     },
     {
-      "githubName": "nrc"
-    },
-    {
       "githubName": "july2993"
-    }
-  ],
-  "reviewers": [
+    },
     {
       "githubName": "9547"
     },
+    {
+      "githubName": "nrc"
+    }
+  ],
+  "reviewers": [
     {
       "githubName": "breeswish"
     },


### PR DESCRIPTION
This reviewer has contributed [45 PRs](https://github.com/pingcap/tiup/pulls?q=is%3Apr+author%3A9547) (42 merged) for [TiUP repo](https://github.com/pingcap/tiup). It's time to promote him as a committer.