### PR TITLE
promote morgo to committer

### DIFF
--- a/special-interest-groups/sig-sql-infra/membership.json
+++ b/special-interest-groups/sig-sql-infra/membership.json
@@ -49,6 +49,9 @@
     },
     {
       "githubName": "xiongjiwei"
+    },
+    {
+      "githubName": "morgo"
     }
   ],
   "reviewers": [
@@ -80,9 +83,6 @@
     },
     {
       "githubName": "blacktear23"
-    },
-    {
-      "githubName": "morgo"
     }
   ]
 }


### PR DESCRIPTION
@morgo now satisfies the requirements for being promoted to a committer.

Requirements

- [x] Have at least [20 PRs](https://github.com/pingcap/tidb/pulls/morgo) merged.
- [x] Have reviewed at [least 10 PRs](https://github.com/pingcap/tidb/pulls?q=is%3Apr+reviewed-by%3Amorgo).
- [x] Nominated by at least 2 Committers or Maintainers.