### PR TITLE
sig-docs: update membership

### DIFF
--- a/special-interest-groups/sig-docs/membership.json
+++ b/special-interest-groups/sig-docs/membership.json
@@ -129,6 +129,9 @@
     },
     {
       "githubName": "Joyinqin"
+    },
+    {
+      "githubName": "dragonly"
     }
   ],
   "activeContributors": [
@@ -223,9 +226,6 @@
       "githubName": "xxj123go"
     },
     {
-      "githubName": "dragonly"
-    },
-    {
       "githubName": "leiysky"
     },
     {
@@ -245,6 +245,15 @@
     },
     {
       "githubName": "yiwu-arbug"
+    },
+    {
+      "githubName": "pepezzzz"
+    },
+    {
+      "githubName": "King-Dylan"
+    },
+    {
+      "githubName": "BinChenn"
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

According to [Be promoted to Reviewer](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-docs/roles-and-organization-management.md#be-promoted-to-reviewer), we would like to promote @dragonly to a new reviewer of Docs SIG. His detailed contribution is shown below:

- Have [merged 20 PRs](https://github.com/pingcap/docs-tidb-operator/pulls?q=is%3Apr+author%3Adragonly) in the docs-tidb-operator repo.
- Have [addressed 2 issues](https://github.com/pingcap/docs-tidb-operator/issues?q=is%3Aissue+assignee%3Adragonly+is%3Aclosed).
- Have a general command of technical writing and documentation rules. See [one of his pull requests](https://github.com/pingcap/docs-tidb-operator/pull/952).

This PR also includes the promotion of 3 active contributors. Please see the changed file for details.