### PR TITLE
Fixed the broken links to Roles and Organization Management for SIGs

### DIFF
--- a/special-interest-groups/sig-bigdata/README.md
+++ b/special-interest-groups/sig-bigdata/README.md
@@ -5,7 +5,7 @@ BigData SIG covers the areas where TiDB and big data are combined, including but
 Anyone who focuses on big data and TiDB is welcomed to join the SIG.
 
 ## Roles and Organization Management
-See [SIG Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-bigdata/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-bigdata/README.md
+++ b/special-interest-groups/sig-bigdata/README.md
@@ -5,7 +5,7 @@ BigData SIG covers the areas where TiDB and big data are combined, including but
 Anyone who focuses on big data and TiDB is welcomed to join the SIG.
 
 ## Roles and Organization Management
-See [SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-bigdata/README.md)
+See [SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-bigdata/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-community-infra/README.md
+++ b/special-interest-groups/sig-community-infra/README.md
@@ -7,7 +7,7 @@ Community-Infra SIG covers the development of [ti-community-infra](https://githu
 
 ## Roles and Organization Management
 
-See [SIG Community-Infra Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG Community-Infra Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-community-infra/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-community-infra/README.md
+++ b/special-interest-groups/sig-community-infra/README.md
@@ -7,7 +7,7 @@ Community-Infra SIG covers the development of [ti-community-infra](https://githu
 
 ## Roles and Organization Management
 
-See [SIG Community-Infra Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-community-infra/README.md)
+See [SIG Community-Infra Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-community-infra/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-diagnosis/README.md
+++ b/special-interest-groups/sig-diagnosis/README.md
@@ -6,7 +6,7 @@ Common approaches may be introducing new UI pages in [TiDB Dashboard](https://gi
 
 ## Roles and Organization Management
 
-See [Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-diagnosis/README.md)
+See [Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-diagnosis/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-diagnosis/README.md
+++ b/special-interest-groups/sig-diagnosis/README.md
@@ -6,7 +6,7 @@ Common approaches may be introducing new UI pages in [TiDB Dashboard](https://gi
 
 ## Roles and Organization Management
 
-See [Roles and Organization Management](./roles-and-organization-management.md)
+See [Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-diagnosis/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-docs/README.md
+++ b/special-interest-groups/sig-docs/README.md
@@ -18,7 +18,7 @@ Docs SIG covers the documentation of all PingCAP products, tools, or projects, b
 
 ## Roles and Organization Management
 
-See [Docs SIG Roles and Organization Management](./roles-and-organization-management.md).
+See [Docs SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-docs/README.md).
 
 ## Members
 

--- a/special-interest-groups/sig-docs/README.md
+++ b/special-interest-groups/sig-docs/README.md
@@ -18,7 +18,7 @@ Docs SIG covers the documentation of all PingCAP products, tools, or projects, b
 
 ## Roles and Organization Management
 
-See [Docs SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-docs/README.md).
+See [Docs SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-docs/roles-and-organization-management.md).
 
 ## Members
 

--- a/special-interest-groups/sig-exec/README.md
+++ b/special-interest-groups/sig-exec/README.md
@@ -11,7 +11,7 @@ Operator](https://pingcap.com/docs/dev/reference/sql/functions-and-operators/ref
 
 ## Roles and Organization Management
 
-See [SIG Exec Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-exec/README.md)
+See [SIG Exec Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-exec/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-exec/README.md
+++ b/special-interest-groups/sig-exec/README.md
@@ -11,7 +11,7 @@ Operator](https://pingcap.com/docs/dev/reference/sql/functions-and-operators/ref
 
 ## Roles and Organization Management
 
-See [SIG Exec Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG Exec Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-exec/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-k8s/README.md
+++ b/special-interest-groups/sig-k8s/README.md
@@ -7,7 +7,7 @@ K8s SIG covers the TiDB Products on Kubernetes and Docker. Our work includes
 
 ## Roles and Organization Management
 
-See [SIG K8s Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG K8s Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-k8s/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-k8s/README.md
+++ b/special-interest-groups/sig-k8s/README.md
@@ -7,7 +7,7 @@ K8s SIG covers the TiDB Products on Kubernetes and Docker. Our work includes
 
 ## Roles and Organization Management
 
-See [SIG K8s Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-k8s/README.md)
+See [SIG K8s Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-k8s/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-migrate/README.md
+++ b/special-interest-groups/sig-migrate/README.md
@@ -14,7 +14,7 @@ Our work includes
 
 ## Roles and Organization Management
 
-See [SIG-Migrate Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG-Migrate Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-migrate/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-migrate/README.md
+++ b/special-interest-groups/sig-migrate/README.md
@@ -14,7 +14,7 @@ Our work includes
 
 ## Roles and Organization Management
 
-See [SIG-Migrate Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-migrate/README.md)
+See [SIG-Migrate Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-migrate/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-planner/README.md
+++ b/special-interest-groups/sig-planner/README.md
@@ -10,7 +10,7 @@ and [statistics](https://pingcap.com/docs/stable/reference/performance/statistic
 
 ## Roles and Organization Management
 
-See [Planner SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-planner/README.md)
+See [Planner SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-planner/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-planner/README.md
+++ b/special-interest-groups/sig-planner/README.md
@@ -10,7 +10,7 @@ and [statistics](https://pingcap.com/docs/stable/reference/performance/statistic
 
 ## Roles and Organization Management
 
-See [Planner SIG Roles and Organization Management](./roles-and-organization-management.md)
+See [Planner SIG Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-planner/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-tiup/README.md
+++ b/special-interest-groups/sig-tiup/README.md
@@ -7,7 +7,7 @@ TiUP SIG covers the development of [TiUP](https://github.com/pingcap-incubator/t
 
 ## Roles and Organization Management
 
-See [SIG TiUP Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-tiup/README.md)
+See [SIG TiUP Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-tiup/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-tiup/README.md
+++ b/special-interest-groups/sig-tiup/README.md
@@ -7,7 +7,7 @@ TiUP SIG covers the development of [TiUP](https://github.com/pingcap-incubator/t
 
 ## Roles and Organization Management
 
-See [SIG TiUP Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG TiUP Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-tiup/README.md)
 
 ## Members
 

--- a/special-interest-groups/sig-web/README.md
+++ b/special-interest-groups/sig-web/README.md
@@ -11,7 +11,7 @@ Web SIG focus on website development around tidb, includding:
 
 ## Roles and Organization Management
 
-See [SIG Web Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-web/README.md)
+See [SIG Web Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-web/roles-and-organization-management.md)
 
 ## Members
 

--- a/special-interest-groups/sig-web/README.md
+++ b/special-interest-groups/sig-web/README.md
@@ -11,7 +11,7 @@ Web SIG focus on website development around tidb, includding:
 
 ## Roles and Organization Management
 
-See [SIG Web Roles and Organization Management](./roles-and-organization-management.md)
+See [SIG Web Roles and Organization Management](https://github.com/pingcap/community/blob/master/special-interest-groups/sig-web/README.md)
 
 ## Members
 


### PR DESCRIPTION
In https://developer.tidb.io/sig, the links to Roles and Organization Management are broken. 

For example, if you click  **Docs SIG Roles and Organization Management** in https://developer.tidb.io/sig/docs, you will get the 404 error. 

This PR changes the relative paths to the actual paths to fix the broken links. 