### PR TITLE
fix: refine typo

### DIFF
--- a/contributors/README.md
+++ b/contributors/README.md
@@ -27,7 +27,7 @@ This document outlines some conventions about development workflow, commit messa
 
 ### Sign the CLA
 
-Click the **Sign in with Github to agree** button to sign the CLA. See an example [here](https://cla-assistant.io/pingcap/tidb?pullRequest=16303).
+Click the **Sign in with GitHub to agree** button to sign the CLA. See an example [here](https://cla-assistant.io/pingcap/tidb).
 
 What is [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement)?
 


### PR DESCRIPTION
It should be `GitHub` and we don't need to add the parameter.