### PR TITLE
fix: fix typo in tidb membership.json

### DIFF
--- a/teams/tidb/membership.json
+++ b/teams/tidb/membership.json
@@ -87,7 +87,7 @@
         "js00070",
         "lamxTyler",
         "lcwangchao",
-        "LittleFall"
+        "LittleFall",
         "longfangsong",
         "mjonss",
         "nolouch",


### PR DESCRIPTION
The wrong JSON format caused an error in the program that synchronizes membership data, fix it.

Maybe we should introduce a CI(Github Actions) to verify the format.