### PR TITLE
disallow exchanging roles between teams

### DIFF
--- a/teams/README.md
+++ b/teams/README.md
@@ -72,9 +72,11 @@ If you disagree with a valid veto, you must lobby the person casting the veto to
 
 | Actions            | Description                                                                               | Approval      | Binding Voters     | Minimum Length (days) |
 | :----------------- | :---------------------------------------------------------------------------------------- | :------------ | :----------------- | :-------------------- |
-| New Reviewer       | When a new reviewer is proposed for the team, should be only nominated by a maintainer.   | Lazy Majority | Active maintainers | 3                     |
+| New Reviewer       | When a new reviewer is proposed for the team, should be only nominated by a committer.    | Lazy Majority | Active maintainers | 3                     |
 | New Committer      | When a new committer is proposed for the team, should be only nominated by a maintainer.  | Consensus     | Active maintainers | 6                     |
 | New Maintainer     | When a new maintainer is proposed for the team, should be only nominated by a maintainer. | Consensus     | Active maintainers | 6                     |
 | Reviewer Removal   | When removal of review privileges is sought.                                              | Consensus     | Active maintainers | 6                     |
 | Committer Removal  | When removal of commit privileges is sought.                                              | Consensus     | Active maintainers | 6                     |
 | Maintainer Removal | When removal of maintain privileges is sought.                                            | Consensus     | Active maintainers | 6                     |
+
+Roles are not exchangeable between teams since each team might has its own management rules. But it is allowed for a team member to self-nominate him/herself for another team to reduce some roundtrip communication. 


### PR DESCRIPTION
I'd like to propose three new details for our governance model.

1. reviewer could be nominated by committers, hope to reduce maintainers' work and find more reviewers
2. roles are not exchangeable between teams. currently, docs team has their own management rule https://github.com/pingcap/community/blob/master/teams/docs/docs-team-management.md different with other teams, a tidb committer may not be a qualified docs reviewer/committer/maintainer.
3. although each team might has its own rules, but teams are also highly connected. a contributor may participate in several teams at the same time, so I think if a contributor has been one team's member, allowing him/her to nominate him/herself for another team could reduce unnecessary communication. Of course, the nomination needs to be approved by the targeted team's maintainers.