### PR TITLE
add AndreMouche as committer

### DIFF
--- a/teams/tidb/membership.json
+++ b/teams/tidb/membership.json
@@ -32,6 +32,7 @@
     "committers": [
         "3pointer",
         "AilinKid",
+	"AndreMouche",
         "AndrewDi",
         "Deardrops",
         "Ehco1996",


### PR DESCRIPTION
This is not a vote. AndreMouche has the priviledges before but during migration seems it's lost. Her contributions could been checked: https://github.com/pingcap/tidb/pulls?q=is%3Apr+AndreMouche+is%3Aclosed