### PR TITLE
add tiflash team

### DIFF
--- a/teams/tiflash/README.md
+++ b/teams/tiflash/README.md
@@ -1,0 +1,11 @@
+# TiFlash Team
+
+TiFlash team is responsible for Analytical Processing (AP) part in the Hybrid Transactional/Analytical Processing (HTAP) architecture of TiDB. 
+
+## Members
+
+See [membership.json](membership.json)
+
+## Code Locations
+
+* [tiflash](https://github.com/pingcap/tiflash)

--- a/teams/tiflash/membership.json
+++ b/teams/tiflash/membership.json
@@ -17,6 +17,7 @@
         "XuHuaiyu",
         "bestwoody",
         "birdstorm",
+        "breeswish",
         "fuzhe1989",
         "fzhedu",
         "gengliqi",

--- a/teams/tiflash/membership.json
+++ b/teams/tiflash/membership.json
@@ -12,7 +12,9 @@
     "committers": [
         "CalvinNeo",
         "JaySon-Huang",
+        "JinheLin",
         "Lloyd-Pottiger",
+        "SchrodingerZhu",
         "SeaRise",
         "XuHuaiyu",
         "bestwoody",

--- a/teams/tiflash/membership.json
+++ b/teams/tiflash/membership.json
@@ -1,0 +1,44 @@
+{
+    "_comment": "Items of lists in this file are in alphabetical order. Please keep it on modification.",
+
+    "description": "TiFlash team is responsible for Analytical Processing (AP) part in the Hybrid Transactional/Analytical Processing (HTAP) architecture of TiDB.",
+
+    "maintainers": [
+        "flowbehappy",
+        "ilovesoup",
+        "zanmato1984"
+    ],
+
+    "committers": [
+        "CalvinNeo",
+        "JaySon-Huang",
+        "Lloyd-Pottiger",
+        "SeaRise",
+        "XuHuaiyu",
+        "bestwoody",
+        "birdstorm",
+        "fuzhe1989",
+        "fzhedu",
+        "gengliqi",
+        "guo-shaoge",
+        "hehechen",
+        "ichn-hu",
+        "jiaqizho",
+        "lidezhu",
+        "littlefall",
+        "mengxin9014",
+        "solotzg",
+        "windtalker",
+        "wshwsh12",
+        "yibin87"
+    ],
+
+    "reviewers": [
+        "LiSong0214",
+        "ywqzzy"
+    ],
+
+    "repositories": [
+        "tiflash"
+    ]
+}


### PR DESCRIPTION
TiFlash is open source on April 1st. It should follow the governance model of TiDB community now. This PR establish the new TiFlash team and its initial team members.

After merge of this PR, I'll create corresponding GitHub team and @Mini256 would change the bot configuration. Previous members of TiFlash repo would be removed. cc @luzizhuo