### PR TITLE
teams/tiflash: a vote for hongyunyan as a committer 

### DIFF
--- a/teams/tiflash/membership.json
+++ b/teams/tiflash/membership.json
@@ -34,7 +34,8 @@
         "windtalker",
         "wshwsh12",
         "yibin87",
-        "ywqzzy"
+        "ywqzzy",
+        "hongyunyan"
     ],
 
     "reviewers": [

--- a/votes/697-hongyunyan-as-tiflash-committer.md
+++ b/votes/697-hongyunyan-as-tiflash-committer.md
@@ -1,0 +1,19 @@
+# A Vote for hongyunyan as TiFlash Committer
+
+## Proposal
+
+During the few months, [@hongyunyan](https://github.com/hongyunyan) has focused on the development of TiFlash.  She has posted [12 PRs](https://github.com/pingcap/tiflash/pulls/hongyunyan) and 10 PRs merged. She is very familiar with the DDL module of TiFlash and made a sharing about DDL's code review.
+
+I (@flowbehappy) hereby nominate @hongyunyan as TiFlash committer and call for a vote.
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection or not enough votes.
+
+## Scope
+
+* TiFlash
+
+## Result
+
+TBD


### PR DESCRIPTION
# A Vote for hongyunyan as TiFlash Committer

## Proposal

During the few months, [@hongyunyan](https://github.com/hongyunyan) has focused on the development of TiFlash.  She has posted [12 PRs](https://github.com/pingcap/tiflash/pulls/hongyunyan) and 10 PRs merged. She is very familiar with the DDL module of TiFlash and made a sharing about DDL's code review.

I (@flowbehappy) hereby nominate @hongyunyan as TiFlash committer and call for a vote.

## Deadline

The vote will be open for at least 6 days unless there is an objection or not enough votes.

## Scope

* TiFlash
