### PR TITLE
docs(contributors): update command-help.md

### DIFF
--- a/contributors/command-help.md
+++ b/contributors/command-help.md
@@ -2,116 +2,20 @@
 
 ## Continuous Integration(CI) Commands
 
-Supported Repositories:
+| repo                                                      | commands                                                                        |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [pingcap/tidb](https://github.com/pingcap/tidb)           | [Command Help](https://prow.tidb.net/command-help?repo=pingcap%2Ftidb)          |
+| [pingcap/tiflash](https://github.com/pingcap/tiflash)     | [Command Help](https://prow.tidb.net/command-help?repo=pingcap%2Ftiflash)       |
+| [pingcap/tiflow](https://github.com/pingcap/tiflow)       | [Command Help](https://prow.tidb.net/command-help?repo=pingcap%2Ftiflow)        |
+| [pingcap/tispark](https://github.com/pingcap/tispark)     | [Command Help](https://prow.tidb.net/command-help?repo=pingcap%2Ftispark)       |
+| [tidb-binlog](https://github.com/pingcap/tidb-binlog)     | [Command Help](https://prow.tidb.net/command-help?repo=pingcap%2Ftidb-binlog)   |
+| [tidb-operator](https://github.com/pingcap/tidb-operator) | [Command Help](https://prow.tidb.net/command-help?repo=pingcap%2Ftidb-operator) |
+| [tikv/tikv](https://github.com/tikv/tikv)                 | [Command Help](https://prow.tidb.net/command-help?repo=tikv%2Ftikv)             |
+| [tikv/pd](https://github.com/tikv/pd)                     | [Command Help](https://prow.tidb.net/command-help?repo=tikv%2Fpd)               |
 
-* [tidb](https://github.com/pingcap/tidb)
-* [tikv](https://github.com/tikv/tikv)
-* [pd](https://github.com/pingcap/pd)
-* [tispark](https://github.com/pingcap/tispark)
-* [tidb-binlog](https://github.com/pingcap/tidb-binlog)
-* [tidb-operator](https://github.com/pingcap/tidb-operator)
 
-### `/rebuild`
+For more other repositories, please go to the [prow command help page]([repositories](https://prow.tidb.net/command-help)) and query with repository.
 
-#### Description
+## Custom CI Parameters
 
-Build the binary based on the PR for testing. It also reruns the following
-continuous integration(CI) test cases:
-
-* `unit-test`
-* `build`
-* `build_check_race`
-* `check_dev`
-* `check_dev_2`
-
-### `/run-all-tests`
-
-#### Description
-
-Triggers all the CI test cases. Here is the list of all the CI test cases:
-
-* `integration-common-test`
-* `integration-compatibility-test`
-* `integration-ddl-test`
-
-For the [tidb](https://github.com/pingcap/tidb) repository, there are five more
-test cases in the CI:
-
-* `unit-test`
-* `common-test`
-* `mybatis-test`
-* `sqllogic-test-1`
-* `sqllogic-test-2`
-
-#### Parameters
-
-```
-# specify which tidb to use
-tidb=<branch>|<pr/$num>
-
-# specify which tikv to use
-tikv=<branch>|<pr/$num>
-
-# specify which pd to use
-pd=<branch>|<pr/$num>
-
-# specify which tidb-test to use
-tidb-test=<branch>|<pr/$num>
-
-# specify which tidb-private-test to use
-tidb-private-test=<branch>|<pr/$num>
-```
-
-#### Examples
-
-```
-/run-all-tests tidb-test=pr/666
-/run-all-tests tidb-test=release-2.1
-/run-all-tests tikv=pr/999
-```
-
-### /run-{{some}}-test
-
-#### Description
-
-Run a single CI test. All the supported tests are:
-
-```
-/run-common-test
-/run-integration-common-test
-/run-integration-compatibility-test
-/run-integration-ddl-test
-/run-mybatis-test
-/run-sqllogic-test-1
-/run-sqllogic-test-2
-/run-unit-test
-```
-
-> **NOTE**: Some repo may not have some of the above tests. For example:
-> `sqllogic-test-1`/`sqllogic-test-2` don't have any meaning on the
-> `tidb-binlog` repo.
-
-#### Parameters
-
-The same as `/run-all-tests`
-
-#### Examples
-
-```
-/run-unit-test
-```
-
-## Pull Request Commands
-
-### `/run-auto-merge`/`/merge`
-
-Add a PR to a internal job queue.
-
-> **NOTE**: The PR must have `can merge` label.
-
-### `/run-cherry-picker`
-
-Triggers a cherry pick for a PR.
-
-> **NOTE**: The PR must have the `needs-cherry-pick-{{release-num}}` labels to
-> indicate which release branch this should be cherry picked to.
+See [CI parameters](https://pingcap.github.io/tidb-dev-guide/get-started/write-and-run-unit-tests.html#ci-parameters).


### PR DESCRIPTION
## Why
Current the page is outdated, the page content is almost about CI jobs triggers, less about other.

## What
Update to the prow command page link, and the command is not fixed for pipelines(the pipeline may be renamed or delete or we add some new ones).
