### PR TITLE
teams/tidb: fix missing change

### DIFF
--- a/teams/tidb/membership.json
+++ b/teams/tidb/membership.json
@@ -37,6 +37,7 @@
         "AilinKid",
         "AndreMouche",
         "AndrewDi",
+        "Benjamin2037",
         "D3Hunter",
         "Deardrops",
         "Defined2014",
@@ -93,7 +94,6 @@
         "zanmato1984"
     ],
     "reviewers": [
-        "Benjamin2037",
         "BornChanger",
         "ChenPeng2013",
         "CabinfeverB",


### PR DESCRIPTION
In https://github.com/pingcap/community/pull/726, I forgot to change the `membership.json` for Benjamin2037. Now I want to add him back.