### PR TITLE
a vote for lidezhu as a committer

### DIFF
--- a/teams/migration/membership.json
+++ b/teams/migration/membership.json
@@ -47,7 +47,8 @@
         "suzaku",
         "zhaoxinyu",
         "zwj-coder",
-        "hongyunyan"
+        "hongyunyan",
+        "lidezhu"
     ],
 
     "reviewers": [

--- a/votes/0782-lidezhu-as-migration-committer.md
+++ b/votes/0782-lidezhu-as-migration-committer.md
@@ -1,0 +1,19 @@
+# A Vote for lidezhu as Migration Committer
+
+## Proposal
+
+[lidezhu](https://github.com/lidezhu) have contributed a lot to TiFlow repo, he has fixed several issues and has been doing some enhancement work in TiCDC.
+
+I (@asddongmen) hereby nominate @lidezhu as migration committer and call for a vote.
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection or not enough votes.
+
+## Scope
+
+* Team Migration
+
+## Result
+
+See also [here](https://github.com/pingcap/community/pull/782).


### PR DESCRIPTION
# A Vote for lidezhu as Migration Committer

## Proposal

[lidezhu](https://github.com/lidezhu) have contributed a lot to TiFlow repo, he has fixed several issues and has been doing some enhancement work in TiCDC.

I (@asddongmen) hereby nominate @lidezhu as migration committer and call for a vote.

## Deadline

The vote will be open for at least 6 days unless there is an objection or not enough votes.

## Scope

* Team Migration

## Result

See also [here](https://github.com/pingcap/community/pull/782).
