### PR TITLE
teams/migration: A Vote for zhangjinpeng87 as Migration Committer

### DIFF
--- a/teams/migration/membership.json
+++ b/teams/migration/membership.json
@@ -48,7 +48,8 @@
         "zhaoxinyu",
         "zwj-coder",
         "hongyunyan",
-        "lidezhu"
+        "lidezhu",
+        "zhangjinpeng87"
     ],
 
     "reviewers": [

--- a/teams/migration/membership.json
+++ b/teams/migration/membership.json
@@ -34,9 +34,11 @@
         "gozssky",
         "hicqu",
         "holys",
+        "hongyunyan",
         "july2993",
         "leoppro",
         "lichunzhu",
+        "lidezhu",
         "liuzix",
         "lonng",
         "maxshuang",
@@ -45,11 +47,9 @@
         "overvenus",
         "sdojjy",
         "suzaku",
+        "zhangjinpeng87",
         "zhaoxinyu",
-        "zwj-coder",
-        "hongyunyan",
-        "lidezhu",
-        "zhangjinpeng87"
+        "zwj-coder"
     ],
 
     "reviewers": [

--- a/votes/0783-zhangjinpeng87-as-migration-committer.md
+++ b/votes/0783-zhangjinpeng87-as-migration-committer.md
@@ -2,7 +2,7 @@
 
 ## Proposal
 
-[@zhangjinpeng87](https://github.com/zhangjinpeng87) is the head of TiDB Data Platform team. He has focused on the system architecture and further iteration of data migration, and contributed greatly to the stability and observability of TiCDC.
+[@zhangjinpeng87](https://github.com/zhangjinpeng87) is the head of TiDB Data Platform team. He has focused on the system architecture and further iteration of data migration, and contributed greatly to improving the stability and observability of TiCDC.
 
 Here lists the details of his contribution:
 

--- a/votes/0783-zhangjinpeng87-as-migration-committer.md
+++ b/votes/0783-zhangjinpeng87-as-migration-committer.md
@@ -1,0 +1,29 @@
+# A Vote for zhangjinpeng87 as Migration Committer
+
+## Proposal
+
+[@zhangjinpeng87](https://github.com/zhangjinpeng87) is the head of TiDB Data Platform team. He has focused on the system architecture and further iteration of data migration, and contributed greatly to the stability and observability of TiCDC.
+
+Here lists the details of his contribution:
+
+* [Authored pull requests in TiFlow](https://github.com/pingcap/tiflow/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+author%3Azhangjinpeng87)
+* [Authored issues in TiFlow](https://github.com/pingcap/tiflow/issues?q=is%3Aissue+author%3Azhangjinpeng87)
+
+I (@CharlesCheung96) hereby nominate @zhangjinpeng87 as migration committer and call for a vote for the following reasons:
+
+* Deep contributions on TiCDC.
+* Reviewed and commented many important issues and PRs.
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection or not enough votes.
+
+## Scope
+
+* Team Migration
+
+## Result
+
+Approved by x binding votes
+
+See also https://github.com/pingcap/community/pull/783.


### PR DESCRIPTION
# A Vote for zhangjinpeng87 as Migration Committer

## Proposal

[@zhangjinpeng87](https://github.com/zhangjinpeng87) is the head of TiDB Data Platform team. He has focused on the system architecture and further iteration of data migration, and contributed greatly to improving the stability and observability of TiCDC.

Here lists the details of his contribution:

* [Authored pull requests in TiFlow](https://github.com/pingcap/tiflow/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+author%3Azhangjinpeng87)
* [Authored issues in TiFlow](https://github.com/pingcap/tiflow/issues?q=is%3Aissue+author%3Azhangjinpeng87)

I (@CharlesCheung96) hereby nominate @zhangjinpeng87 as migration committer and call for a vote for the following reasons:

* Deep contributions on TiCDC.
* Reviewed and commented many important issues and PRs.

## Deadline

The vote will be open for at least 6 days unless there is an objection or not enough votes.

## Scope

* Team Migration

## Result

Approved by x binding votes

See also https://github.com/pingcap/community/pull/783.
