### PR TITLE
Add emeritus approvers to docs

### DIFF
--- a/teams/docs/docs-team-management.md
+++ b/teams/docs/docs-team-management.md
@@ -37,6 +37,6 @@ Before you are promoted to a Committer, you are expected to meet all the followi
 
 ## Emeritus approvers
 
-[Emeritus approvers](/teams/docs/membership.json#L26) are contributors who were previously active as approvers (in the [`committers`](/teams/docs/membership.json#L11) section) but have stepped back due to shifting priorities, job changes, or other reasons. [`emeritus_approvers`](/teams/docs/membership.json#L26) lists the GitHub ID of emeritus approvers.
+[Emeritus approvers](/teams/docs/membership.json#L26) are contributors who were previously active as approvers (in the [`committers`](/teams/docs/membership.json#L11) section) but have stepped back due to shifting priorities, job changes, or other reasons. The [`emeritus_approvers`](/teams/docs/membership.json#L26) section lists the GitHub IDs of emeritus approvers.
 
 Emeritus approvers no longer have the authority to approve changes. If they become active contributors again, they can be reinstated as regular approvers with the consent of the current approvers.

--- a/teams/docs/docs-team-management.md
+++ b/teams/docs/docs-team-management.md
@@ -34,3 +34,9 @@ Before you are promoted to a Committer, you are expected to meet all the followi
 - Have reviewed at least 20 PRs in documentation repositories within one year
 - Play an important role in a big feature
 - Be able to guarantee the quality of the merged PRs
+
+## Emeritus approvers
+
+[Emeritus approvers](/teams/docs/membership.json#L26) are contributors who were previously active as approvers (in the [`committers`](/teams/docs/membership.json#L11) section) but have stepped back due to shifting priorities, job changes, or other reasons. [`emeritus_approvers`](/teams/docs/membership.json#L26) lists the GitHub ID of emeritus approvers.
+
+Emeritus approvers no longer have the authority to approve changes. If they become active contributors again, they can be reinstated as regular approvers with the consent of the current approvers.

--- a/teams/docs/membership.json
+++ b/teams/docs/membership.json
@@ -4,40 +4,45 @@
     "description": "Docs team covers the documentation of all PingCAP products, tools, or projects, both in English and in Chinese.",
 
     "maintainers": [
-        "TomShawn",
         "lilin90",
         "qiancai",
-        "yikeke"
     ],
 
     "committers": [
-        "CaitinChen",
-        "CharLotteiu",
-        "DanielZhangQD",
-        "en-jin19",
-        "Icemap",
-        "Liuxiaozhen12",
-        "SunRunAway",
-        "WangXiangUSTC",
-        "YiniXu9506",
         "breezewish",
-        "cofyc",
         "csuzhangxc",
-        "dcalvin",
-        "dragonly",
         "hfxsd",
+        "Icemap",
         "jackysp",
         "kissmydb",
         "lance6716",
-        "lichunzhu",
-        "morgo",
+        "lilin90",
         "Oreoxmt",
         "overvenus",
+        "qiancai",
+        "tangenta"
+    ],
+
+    "emeritus_approvers": [
+        "CaitinChen",
+        "CharLotteiu",
+        "cofyc",
+        "DanielZhangQD",
+        "dcalvin",
+        "dragonly",
+        "en-jin19",
+        "lichunzhu",
+        "Liuxiaozhen12",
+        "morgo",
         "queenypingcap",
         "ran-huang",
         "shichun-0415",
-        "tangenta",
-        "toutdesuite"
+        "SunRunAway",
+        "TomShawn",
+        "toutdesuite",
+        "WangXiangUSTC",
+        "yikeke",
+        "YiniXu9506"
     ],
 
     "reviewers": [


### PR DESCRIPTION
- Adds the "Emeritus approvers" section to [teams/docs/docs-team-management.md](https://github.com/pingcap/community/blob/master/teams/docs/docs-team-management.md)
- Moves inactive contributors from "committers" to "emeritus_approvers" in [teams/docs/membership.json](https://github.com/pingcap/community/blob/master/teams/docs/membership.json)
- Removes two GitHub IDs from the "maintainers" list because they already exist in the "emeritus_approvers" list

Reference: https://github.com/pingcap/docs/pull/19599