### PR TITLE
teams/docs: remove a comma to fix JSON syntax

### DIFF
--- a/teams/docs/membership.json
+++ b/teams/docs/membership.json
@@ -5,7 +5,7 @@
 
     "maintainers": [
         "lilin90",
-        "qiancai",
+        "qiancai"
     ],
 
     "committers": [


### PR DESCRIPTION
Removes a trailing comma after the last item in `teams/docs/membership.json` to fix syntax.