### PR TITLE
teams/ticdc: add teams/ticdc folder for managing TiCDC community

### DIFF
--- a/teams/ticdc/OWNERS
+++ b/teams/ticdc/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+reviewers:
+  - kennytm
+  - flowbehappy
+approvers:
+  - kennytm
+  - flowbehappy

--- a/teams/ticdc/README.md
+++ b/teams/ticdc/README.md
@@ -1,0 +1,11 @@
+# TiCDC Team
+
+The TiCDC team is responsible for the Change Data Capture (CDC) functionality in the TiDB ecosystem, enabling real-time replication to downstream systems such as MySQL, TiDB, Kafka, and object storage. The team drives the development and maintenance of TiCDC, focusing on high performance, scalability, and reliability.
+
+## Members
+
+See [membership.json](membership.json)
+
+## Code Locations
+
+* [ticdc](https://github.com/pingcap/ticdc)

--- a/teams/ticdc/membership.json
+++ b/teams/ticdc/membership.json
@@ -1,0 +1,25 @@
+{
+    "_comment": "Items of lists in this file are in alphabetical order. Please keep it on modification.",
+    "description": "The TiCDC team is responsible for the Change Data Capture (CDC) functionality in the TiDB ecosystem, enabling real-time replication to downstream systems such as MySQL, TiDB, Kafka, and object storage. The team drives the development and maintenance of TiCDC, focusing on high performance, scalability, and reliability.",
+    "maintainers": [
+        "flowbehappy",
+        "kennytm"
+    ],
+    "committers": [
+        "3AceShowHand",
+        "CharlesCheung96",
+        "asddongmen",
+        "hicqu",
+        "hongyunyan",
+        "lidezhu",
+        "sdojjy",
+        "wk989898",
+        "wlwilliamx"
+    ],
+    "reviewers": [
+        
+    ],
+    "repositories": [
+        "ticdc"
+    ]
+}


### PR DESCRIPTION
This PR adds a new `teams/ticdc` folder under the `pingcap/community` repository to manage and organize the TiCDC community.

As TiCDC evolves with its new architecture, having a dedicated folder will help improve community collaboration by:
* Defining roles, responsibilities, and governance for the TiCDC team.
* Centralizing TiCDC-related community activities.

The structure and contents of the folder align with existing teams folders in this repository, ensuring consistency across projects.